### PR TITLE
Add opts.filter to rehype-javascript-to-bottom

### DIFF
--- a/packages/rehype-javascript-to-bottom/index.js
+++ b/packages/rehype-javascript-to-bottom/index.js
@@ -16,41 +16,46 @@ var js = require('hast-util-is-javascript');
 
 module.exports = jsToBottom;
 
-function jsToBottom() {
+function jsToBottom(opts) {
+  opts = opts || {};
+  var filter = opts.filter || function () {
+    return true;
+  };
+
   return transform;
-}
 
-function transform(tree) {
-  var matches = [];
-  var body;
+  function transform(tree) {
+    var matches = [];
+    var body;
 
-  visit(tree, 'element', visitor);
+    visit(tree, 'element', visitor);
 
-  if (body && matches.length !== 0) {
-    move();
-  }
-
-  function visitor(node, index, parent) {
-    if (node.tagName === 'body') {
-      body = node;
+    if (body && matches.length !== 0) {
+      move();
     }
 
-    if (js(node)) {
-      matches.push([parent, node]);
+    function visitor(node, index, parent) {
+      if (node.tagName === 'body') {
+        body = node;
+      }
+
+      if (js(node) && filter(node)) {
+        matches.push([parent, node]);
+      }
     }
-  }
 
-  function move() {
-    var length = matches.length;
-    var index = -1;
-    var match;
-    var siblings;
+    function move() {
+      var length = matches.length;
+      var index = -1;
+      var match;
+      var siblings;
 
-    while (++index < length) {
-      match = matches[index];
-      siblings = match[0].children;
-      siblings.splice(siblings.indexOf(match[1]), 1);
-      body.children.push(match[1]);
+      while (++index < length) {
+        match = matches[index];
+        siblings = match[0].children;
+        siblings.splice(siblings.indexOf(match[1]), 1);
+        body.children.push(match[1]);
+      }
     }
   }
 }

--- a/packages/rehype-javascript-to-bottom/test.js
+++ b/packages/rehype-javascript-to-bottom/test.js
@@ -47,5 +47,27 @@ test('rehype-javascript-to-bottom', function (t) {
     h('body', h('link', {rel: ['stylesheet'], href: 'index.css'}))
   );
 
+  function ignoreFoo(node) {
+    return !/foo.js/.test(node.properties.src);
+  }
+
+  t.deepEqual(
+    rehype().use(min, {filter: ignoreFoo}).runSync(u('root', [
+      h('head', [
+        h('script', {src: 'index.js'}),
+        h('script', {src: 'foo.js'})
+      ]),
+      h('body', [])
+    ])),
+    u('root', [
+      h('head', [
+        h('script', {src: 'foo.js'})
+      ]),
+      h('body', [
+        h('script', {src: 'index.js'})
+      ])
+    ])
+  );
+
   t.end();
 });


### PR DESCRIPTION
First, thanks for all of the helpers.

Here, I added opts.filter. In my use case, I don't want to move certain scripts (analytics) to the bottom.